### PR TITLE
Fixed some flaws in StatefulTrait.

### DIFF
--- a/src/KPhoen/DoctrineStateMachineBehavior/Entity/StatefulTrait.php
+++ b/src/KPhoen/DoctrineStateMachineBehavior/Entity/StatefulTrait.php
@@ -65,8 +65,12 @@ trait StatefulTrait
             return $this->stateMachine->can(strtolower(substr($method, 3)));
         } elseif (substr($method, 0, 2) === 'is' && isset($states[strtolower(substr($method, 2))])) {
             return $this->stateMachine->getCurrentState()->getName() === strtolower(substr($method, 2));
+        } elseif ('apply' === $method) {
+            return $this->stateMachine->apply($arguments[0]);
         } elseif (isset($transitions[$method])) {
-            $this->stateMachine->apply($method);
+            return $this->stateMachine->apply($method);
         }
+        
+        throw new \BadMethodCallException(sprintf('The method "::%s()" on class "%s" does not exist.', $method, get_class($this)));
     }
 }


### PR DESCRIPTION
Hi,

I tried to fix two things in the StatefulTrait:
- The first thing is to add the ability to call ->apply('my_transition') instead of ->my_transition() for objects using the StatefulTrait.
- The second thing is to add an exception at the end of __call() because without it, any call to an undefined method fails silently which is _very_ painful.

Feel free to tell me what you think of these changes.

Best regards.
